### PR TITLE
Version bump to 0.0.0-pre.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 types/
 *.tgz
 tsconfig.tsbuildinfo
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.0-pre.4 - 2025-09-18
+
+- rename apiKey to sdkKey
+- change version header
+
 ## 0.0.0-pre.3 - 2025-09-05
 
 - Remove deprecated methods and fix typing on public replacements

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@4.9.2",
   "name": "@reforge-com/javascript",
-  "version": "0.0.0-pre.3",
+  "version": "0.0.0-pre.4",
   "description": "Feature Flags & Dynamic Configuration as a Service",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Description

This updates the version so that consumers of this code (sdk-react, sdk-node) can use the sdkKey naming in their naming updates