### PR TITLE
feat: Bundle size improvements for prefetch config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ prefetchReforgeConfig({
 });
 ```
 
-This lightweight import (~3KB) is ideal for early loading. When you later call `reforge.init()`, it will automatically use the prefetched promise if available.
+This lightweight import (~3KB) is ideal for early loading. When you later call `reforge.init()`, it
+will automatically use the prefetched promise if available.
 
 ## Client API
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To avoid a request waterfall, you can start fetching the configuration early in 
 lifecycle, before the React SDK or `reforge.init()` is called.
 
 ```javascript
-import { prefetchReforgeConfig, Context } from "@reforge-com/javascript";
+import { prefetchReforgeConfig, Context } from "@reforge-com/javascript/prefetch";
 
 prefetchReforgeConfig({
   sdkKey: "1234",
@@ -83,7 +83,7 @@ prefetchReforgeConfig({
 });
 ```
 
-When you later call `reforge.init()`, it will automatically use the prefetched promise if available.
+This lightweight import (~3KB) is ideal for early loading. When you later call `reforge.init()`, it will automatically use the prefetched promise if available.
 
 ## Client API
 

--- a/index.ts
+++ b/index.ts
@@ -8,8 +8,11 @@ import {
 import { Config } from "./src/config";
 import Context from "./src/context";
 import { LogLevel, getLogLevelSeverity, shouldLogAtLevel } from "./src/logger";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { version } = require("./package.json");
+
+/* eslint-disable no-underscore-dangle */
+declare const __SDK_VERSION__: string;
+const version = __SDK_VERSION__;
+/* eslint-enable no-underscore-dangle */
 
 export {
   reforge,

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,9 @@
 
 import type { Config } from "jest";
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJson = require("./package.json");
+
 const config: Config = {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
@@ -67,7 +70,9 @@ const config: Config = {
   // globalTeardown: undefined,
 
   // A set of global variables that need to be available in all test environments
-  // globals: {},
+  globals: {
+    __SDK_VERSION__: packageJson.version,
+  },
 
   // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/eslint-plugin-jsx-a11y": "^6",
     "@types/express": "^4.17.13",
     "@types/jest": "^28.1.6",
-    "@types/uuid": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^5.33.0",
     "@typescript-eslint/parser": "^5.33.0",
     "esbuild": "^0.25.11",
@@ -55,14 +54,17 @@
     "url": "https://github.com/ReforgeHQ/sdk-javascript/issues"
   },
   "homepage": "https://github.com/ReforgeHQ/sdk-javascript#readme",
-  "dependencies": {
-    "uuid": "^9.0.1"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
+    },
+    "./prefetch": {
+      "types": "./dist/src/prefetch.d.ts",
+      "import": "./dist/src/prefetch.mjs",
+      "require": "./dist/src/prefetch.cjs"
     }
-  }
+  },
+  "sideEffects": false
 }

--- a/src/prefetch.test.ts
+++ b/src/prefetch.test.ts
@@ -13,7 +13,7 @@ describe("prefetchReforgeConfig", () => {
     // Reset window object
     (window as any).REFORGE_SDK_PREFETCH_PROMISE = undefined;
     jest.clearAllMocks();
-    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => { });
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/src/prefetch.ts
+++ b/src/prefetch.ts
@@ -1,0 +1,45 @@
+import Context from "./context";
+import Loader, { CollectContextModeType } from "./loader";
+
+// Re-export Context so consumers can create contexts for prefetch
+export { Context };
+
+/* eslint-disable no-underscore-dangle */
+declare const __SDK_VERSION__: string;
+const version = __SDK_VERSION__;
+/* eslint-enable no-underscore-dangle */
+
+export type PrefetchParams = {
+  sdkKey: string;
+  context: Context;
+  endpoints?: string[] | undefined;
+  timeout?: number;
+  collectContextMode?: CollectContextModeType;
+  clientNameString?: string;
+  clientVersionString?: string;
+};
+
+export function prefetchReforgeConfig({
+  sdkKey,
+  context,
+  endpoints = undefined,
+  timeout = undefined,
+  collectContextMode = "PERIODIC_EXAMPLE",
+  clientNameString = "sdk-javascript",
+  clientVersionString = version,
+}: PrefetchParams) {
+  const clientNameAndVersionString = `${clientNameString}-${clientVersionString}`;
+
+  const loader = new Loader({
+    sdkKey,
+    context,
+    endpoints,
+    timeout,
+    collectContextMode,
+    clientVersion: clientNameAndVersionString,
+  });
+
+  (window as any).REFORGE_SDK_PREFETCH_PROMISE = loader.load();
+}
+
+export default prefetchReforgeConfig;

--- a/src/reforge.ts
+++ b/src/reforge.ts
@@ -159,7 +159,7 @@ export class Reforge {
 
   public loader: Loader | undefined;
 
-  public afterEvaluationCallback = (() => { }) as EvaluationCallback;
+  public afterEvaluationCallback = (() => {}) as EvaluationCallback;
 
   private _context: Context = new Context({});
 
@@ -177,7 +177,7 @@ export class Reforge {
     endpoints = undefined,
     apiEndpoint,
     timeout = undefined,
-    afterEvaluationCallback = () => { },
+    afterEvaluationCallback = () => {},
     collectEvaluationSummaries = true,
     collectLoggerNames = false,
     collectContextMode = "PERIODIC_EXAMPLE",
@@ -377,12 +377,12 @@ export class Reforge {
     // We need to calcuate these live and not store in a type to ensure dynamic evaluation
     // in upstream libraries that override the FrontEndConfigurationRaw interface
     K extends keyof FrontEndConfigurationRaw extends never
-    ? string
-    : {
-      [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends boolean
-      ? IK
-      : never;
-    }[keyof TypedFrontEndConfigurationRaw],
+      ? string
+      : {
+          [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends boolean
+            ? IK
+            : never;
+        }[keyof TypedFrontEndConfigurationRaw],
   >(key: K): boolean {
     return this.get(key) === true;
   }
@@ -418,12 +418,12 @@ export class Reforge {
     // We need to calcuate these live and not store in a type to ensure dynamic evaluation
     // in upstream libraries that override the FrontEndConfigurationRaw interface
     K extends keyof FrontEndConfigurationRaw extends never
-    ? string
-    : {
-      [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends Duration
-      ? IK
-      : never;
-    }[keyof TypedFrontEndConfigurationRaw],
+      ? string
+      : {
+          [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends Duration
+            ? IK
+            : never;
+        }[keyof TypedFrontEndConfigurationRaw],
   >(key: K): Duration | undefined {
     const value = this.get(key);
 

--- a/src/reforge.ts
+++ b/src/reforge.ts
@@ -1,6 +1,4 @@
 /* eslint-disable max-classes-per-file */
-import { v4 as uuid } from "uuid";
-
 import { Config, EvaluationPayload, RawConfigWithoutTypes } from "./config";
 import type {
   Duration,
@@ -20,8 +18,19 @@ import {
 } from "./logger";
 import TelemetryUploader from "./telemetryUploader";
 import { LoggerAggregator } from "./loggerAggregator";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { version } = require("../package.json");
+
+/* eslint-disable no-underscore-dangle */
+declare const __SDK_VERSION__: string;
+const version = __SDK_VERSION__;
+/* eslint-enable no-underscore-dangle */
+
+function uuid() {
+  if (typeof crypto !== "undefined") {
+    return crypto.randomUUID();
+  }
+
+  return Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+}
 
 type EvaluationCallback = <K extends keyof TypedFrontEndConfigurationRaw>(
   key: K,
@@ -150,7 +159,7 @@ export class Reforge {
 
   public loader: Loader | undefined;
 
-  public afterEvaluationCallback = (() => {}) as EvaluationCallback;
+  public afterEvaluationCallback = (() => { }) as EvaluationCallback;
 
   private _context: Context = new Context({});
 
@@ -168,7 +177,7 @@ export class Reforge {
     endpoints = undefined,
     apiEndpoint,
     timeout = undefined,
-    afterEvaluationCallback = () => {},
+    afterEvaluationCallback = () => { },
     collectEvaluationSummaries = true,
     collectLoggerNames = false,
     collectContextMode = "PERIODIC_EXAMPLE",
@@ -368,12 +377,12 @@ export class Reforge {
     // We need to calcuate these live and not store in a type to ensure dynamic evaluation
     // in upstream libraries that override the FrontEndConfigurationRaw interface
     K extends keyof FrontEndConfigurationRaw extends never
-      ? string
-      : {
-          [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends boolean
-            ? IK
-            : never;
-        }[keyof TypedFrontEndConfigurationRaw],
+    ? string
+    : {
+      [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends boolean
+      ? IK
+      : never;
+    }[keyof TypedFrontEndConfigurationRaw],
   >(key: K): boolean {
     return this.get(key) === true;
   }
@@ -409,12 +418,12 @@ export class Reforge {
     // We need to calcuate these live and not store in a type to ensure dynamic evaluation
     // in upstream libraries that override the FrontEndConfigurationRaw interface
     K extends keyof FrontEndConfigurationRaw extends never
-      ? string
-      : {
-          [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends Duration
-            ? IK
-            : never;
-        }[keyof TypedFrontEndConfigurationRaw],
+    ? string
+    : {
+      [IK in keyof TypedFrontEndConfigurationRaw]: TypedFrontEndConfigurationRaw[IK] extends Duration
+      ? IK
+      : never;
+    }[keyof TypedFrontEndConfigurationRaw],
   >(key: K): Duration | undefined {
     const value = this.get(key);
 
@@ -470,27 +479,6 @@ export class Reforge {
 
 export const reforge = new Reforge();
 
-export function prefetchReforgeConfig({
-  sdkKey,
-  context,
-  endpoints = undefined,
-  timeout = undefined,
-  collectContextMode = "PERIODIC_EXAMPLE",
-  clientNameString = "sdk-javascript",
-  clientVersionString = version,
-}: ReforgeInitParams) {
-  const clientNameAndVersionString = `${clientNameString}-${clientVersionString}`;
-
-  const loader = new Loader({
-    sdkKey,
-    context,
-    endpoints,
-    timeout,
-    collectContextMode,
-    clientVersion: clientNameAndVersionString,
-  });
-
-  (window as any).REFORGE_SDK_PREFETCH_PROMISE = loader.load();
-}
-
-export default prefetchReforgeConfig;
+// Re-export prefetchReforgeConfig for backwards compatibility
+export { prefetchReforgeConfig } from "./prefetch";
+export type { PrefetchParams } from "./prefetch";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,17 +1,23 @@
 import { defineConfig } from "tsup";
 import { execSync } from "child_process";
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const packageJson = require("./package.json");
+
 export default defineConfig({
-  entry: ["index.ts"],
+  entry: ["index.ts", "src/prefetch.ts"],
   format: ["cjs", "esm"], // Build both CommonJS and ESM versions
   dts: true, // Generate declaration files
-  splitting: false,
+  splitting: true, // Enable code splitting for smaller imports
   sourcemap: true,
   clean: true, // Clean output directory before build
-  minify: false,
-  external: ["uuid"], // Don't bundle uuid
+  minify: true,
+  external: [],
   noExternal: [],
   outDir: "dist",
+  define: {
+    __SDK_VERSION__: JSON.stringify(packageJson.version),
+  },
   outExtension: ({ format }) => ({
     js: format === "cjs" ? ".cjs" : ".mjs",
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,7 +1295,6 @@ __metadata:
     "@types/eslint-plugin-jsx-a11y": "npm:^6"
     "@types/express": "npm:^4.17.13"
     "@types/jest": "npm:^28.1.6"
-    "@types/uuid": "npm:^9.0.5"
     "@typescript-eslint/eslint-plugin": "npm:^5.33.0"
     "@typescript-eslint/parser": "npm:^5.33.0"
     esbuild: "npm:^0.25.11"
@@ -1315,7 +1314,6 @@ __metadata:
     ts-node: "npm:^10.9.1"
     tsup: "npm:^8.0.2"
     typescript: "npm:^5.1.6"
-    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -1810,13 +1808,6 @@ __metadata:
   version: 4.0.5
   resolution: "@types/tough-cookie@npm:4.0.5"
   checksum: 10c0/68c6921721a3dcb40451543db2174a145ef915bc8bcbe7ad4e59194a0238e776e782b896c7a59f4b93ac6acefca9161fccb31d1ce3b3445cb6faa467297fb473
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^9.0.5":
-  version: 9.0.8
-  resolution: "@types/uuid@npm:9.0.8"
-  checksum: 10c0/b411b93054cb1d4361919579ef3508a1f12bf15b5fdd97337d3d351bece6c921b52b6daeef89b62340fd73fd60da407878432a1af777f40648cbe53a01723489
   languageName: node
   linkType: hard
 
@@ -7577,15 +7568,6 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "uuid@npm:9.0.1"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/1607dd32ac7fc22f2d8f77051e6a64845c9bce5cd3dd8aa0070c074ec73e666a1f63c7b4e0f4bf2bc8b9d59dc85a15e17807446d9d2b17c8485fbc2147b27f9b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Replace package.json require with __SDK_VERSION__ build-time constant
- Add separate prefetch entry point for smaller bundle imports
- Enable code splitting in tsup for tree-shaking
- Add ./prefetch subpath export in package.json
- Export as es2020
- Remove `uuid` dep
- Full bundle: ~14.8KB, Prefetch-only: ~3.2KB (78% smaller)